### PR TITLE
Fix occasional crash in GC

### DIFF
--- a/src/vmobjects/VMString.c
+++ b/src/vmobjects/VMString.c
@@ -54,7 +54,7 @@ pVMString VMString_new(const char* restrict chars) {
  */
 void _VMString_init(void* _self, ...) {
     pVMString self = (pVMString)_self;
-    SUPER(VMObject, self, init, 1);
+    SUPER(VMObject, self, init, 0);
     
     va_list args; 
     va_start(args, _self);

--- a/src/vmobjects/VMSymbol.c
+++ b/src/vmobjects/VMSymbol.c
@@ -56,7 +56,7 @@ pVMSymbol VMSymbol_new(const char* restrict string) {
  */
 void _VMSymbol_init(void* _self, ...) {
     pVMSymbol self = (pVMSymbol)_self;    
-    SUPER(VMObject, self, init, 1);
+    SUPER(VMObject, self, init, 0);
     
     va_list args;
     va_start(args, _self);


### PR DESCRIPTION
- VMString and VMSymbol have no gc'able fields
- the char field actually points at char data
- this data may look like it is in the heap and cause a crash
